### PR TITLE
Add Swagger UI to routed services, include PPDDM Manager and Service Discovery

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,15 +16,27 @@ spring:
     gateway:
       routes:
       - id: oauth_easy_swagger
-        uri: ${OAUTH_EASY_SWAGGER_URL:http://localhost:8081/swagger-ui.html}
+        uri: ${OAUTH_EASY_URL:http://localhost:8081}
         predicates:
         - Path=/oauth/swagger-ui.html
         filters:
-        - RedirectTo=302, http://localhost:8081/swagger-ui.html   
+        - StripPrefix=1   
       - id: oauth_easy
         uri: ${OAUTH_EASY_URL:http://localhost:8081}
         predicates:
         - Path=/oauth/**
+        filters:
+        - StripPrefix=1      
+      - id: discovery_swagger
+        uri: ${DISCOVERY_URL:http://localhost:8082}
+        predicates:
+        - Path=/discovery/swagger-ui.html
+        filters:
+        - StripPrefix=1   
+      - id: discovery
+        uri: ${DISCOVERY_URL:http://localhost:8082}
+        predicates:
+        - Path=/discovery/**
         filters:
         - StripPrefix=1      
       - id: ppddm-manager

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,9 +15,21 @@ spring:
   cloud:
     gateway:
       routes:
+      - id: oauth_easy_swagger
+        uri: ${OAUTH_EASY_SWAGGER_URL:http://localhost:8081/swagger-ui.html}
+        predicates:
+        - Path=/oauth/swagger-ui.html
+        filters:
+        - RedirectTo=302, http://localhost:8081/swagger-ui.html   
       - id: oauth_easy
         uri: ${OAUTH_EASY_URL:http://localhost:8081}
         predicates:
         - Path=/oauth/**
         filters:
         - StripPrefix=1      
+      - id: ppddm-manager
+        uri: ${PPDDM_MANAGER_URL:http://localhost:8181}
+        predicates:
+        - Path=/ppddm-manager/**
+        filters:
+        - StripPrefix=1  


### PR DESCRIPTION
## Proposed Changes

  - Add new routing mechanisms to access Swagger UI of the proxied services
  - Add Service Discovery and PPDDM Manager

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [ ] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Fixes #2 

## What is the new behavior?

- When accessing /oauth/swagger-ui.html (or other) it redirects to the proper html
- It is possible to route PPDDM Manager and Service Discovery

## Does this introduce a breaking change?

- [ ] Yes
- [x] No